### PR TITLE
set arguments to required

### DIFF
--- a/haybaler.py
+++ b/haybaler.py
@@ -119,8 +119,8 @@ def adding_species(path, column, name):
 
 
 @click.command()
-@click.option('--input_file', '-i', help='Name of the input file')
-@click.option('--input_path', '-p', help='Path of the input file')
+@click.option('--input_file', '-i', help='Name of the input file', required=True)
+@click.option('--input_path', '-p', help='Path of the input file', required=True)
 @click.option('--output_path', '-op', help='Name of the output path')
 @click.option('--output_file', '-o', help='Name of the output file')
 def main(input_file, input_path, output_path, output_file):

--- a/haybaler.py
+++ b/haybaler.py
@@ -10,9 +10,10 @@ import click
 import os.path
 import re
 
-version = "0.22 - Feb 2021"
+version = "0.23 - Mar 2021"
 
 # changelog
+# 0.23 improve file input and arg handling
 # 0.22 bugfix, correct gc_ref and chr_length for new chromosomes
 # 0.21 fix ordering problems
 # 0.20 add find_order and sort_new functions, so taxa with highest readcounts come first

--- a/haybaler_taxonomy.py
+++ b/haybaler_taxonomy.py
@@ -51,8 +51,8 @@ def find_genus(split, refseq_name):
 
 
 @click.command()
-@click.option('--input_file', '-i', help='Name of the input file')
-@click.option('--input_path', '-p', help='Path of the input file')
+@click.option('--input_file', '-i', help='Name of the input file', required=True)
+@click.option('--input_path', '-p', help='Path of the input file', required=True)
 def main(input_file, input_path):
 
     pd.set_option('display.max_rows', 100000)


### PR DESCRIPTION
 No bug/weird error message when an argument is missing. Exits if not all required arguments are given and refers to the --help option.