### PR TITLE
create no empty file if a haybaler_short.csv doesn't exist

### DIFF
--- a/haybaler.py
+++ b/haybaler.py
@@ -179,7 +179,7 @@ def shorten_names(output_path, col, output_file):
         short.to_csv(save_name, sep='\t')
 
 
-def subspecies(new_name, n, count,split_name):
+def subspecies(new_name, n, count, split_name):
     if split_name[n+count] == "subsp":
         add = split_name[n+count+1]
         while len(add) == 0:

--- a/runbatch_heatmaps.sh
+++ b/runbatch_heatmaps.sh
@@ -9,7 +9,7 @@
 
 prepare_files () {
   echo "INFO: Preparing files for R heatmap creation"
-  for infile in *haybaler.csv *haybaler_short.csv
+  for infile in $(ls *haybaler.csv *haybaler_short.csv)
         do
         echo "Running on " $infile
 


### PR DESCRIPTION
In some cases the haybaler_short.csvs can not be created. The heatmap creation expected those files to be there though, so a file named `*haybaler_short.csv` was created instead. With this change this doesn't happen anymore